### PR TITLE
Se cambia el comportamiento de la barra de búsqueda al pasar el mouse

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -153,8 +153,9 @@ SEARCH.addEventListener('keyup', (e) => {
 SEARCH.addEventListener('mouseover', function () {
 	this.style.width = '100%';
 	SEARCH.children[1].style.paddingRight = '10px';
+	SEARCH.children[1].focus();
 });
-SEARCH.addEventListener('mouseleave', function () {
-	this.style.width = '49px';
-	SEARCH.children[1].style.paddingRight = 0;
+SEARCH.children[1].addEventListener('blur', function () {
+	SEARCH.style.width = '49px';
+	this.style.paddingRight = 0;
 });


### PR DESCRIPTION
Se cambió la manera en la cual el mouse entra y sale de la barra de búsqueda.
En un principio la barra de búsqueda se extendía y se cerraba al entrar y salir el mouse por encima.
Ahora al pasar el mouse directamente entra en el input y al salir del input se cierra la barra de búsqueda.

**Antes:**
![Old](https://user-images.githubusercontent.com/60558572/115260805-1425e880-a101-11eb-868b-a2a56bb6d24a.gif)

**Después:**
![New](https://user-images.githubusercontent.com/60558572/115260932-30c22080-a101-11eb-820c-6c7d227fdae5.gif)
